### PR TITLE
Add skip logic

### DIFF
--- a/Eject.xcodeproj/project.pbxproj
+++ b/Eject.xcodeproj/project.pbxproj
@@ -187,7 +187,9 @@
 				AB47D9AD1DB5A3DD00A7B5E8 /* Products */,
 				AB530CCC1DD101DE00B54516 /* Tests */,
 			);
+			indentWidth = 4;
 			sourceTree = "<group>";
+			tabWidth = 4;
 		};
 		AB47D9AD1DB5A3DD00A7B5E8 /* Products */ = {
 			isa = PBXGroup;
@@ -232,10 +234,10 @@
 			isa = PBXGroup;
 			children = (
 				ABB389FD1DB95DDB008BF59E /* CodeGeneration.swift */,
+				AB05071A1DD7BA35005B5427 /* ConstraintCodeGenerator.swift */,
 				ABB389FE1DB95DDB008BF59E /* Initializer.swift */,
 				ABB38A051DB95DDB008BF59E /* ValueCodeGenerators.swift */,
 				ABB38A071DB95DDB008BF59E /* VariableConfiguration.swift */,
-				AB05071A1DD7BA35005B5427 /* ConstraintCodeGenerator.swift */,
 			);
 			path = CodeGenerators;
 			sourceTree = "<group>";
@@ -275,6 +277,7 @@
 				ABB38A261DB95E04008BF59E /* ConstraintBuilder.swift */,
 				ABB389F31DB95DDB008BF59E /* DocumentBuilder.swift */,
 				ABB389F41DB95DDB008BF59E /* FontBuilder.swift */,
+				AB9EF7E01DED4BCD0097C3FC /* ItemsBuilder.swift */,
 				ABB389F51DB95DDB008BF59E /* KeyValueBuilder.swift */,
 				ABB389F61DB95DDB008BF59E /* ObjectDefinition+Builder.swift */,
 				ABB389F71DB95DDB008BF59E /* OptionSetBuilder.swift */,
@@ -282,7 +285,6 @@
 				ABF8D90A1DC1197C008D9178 /* SegmentsBuilder.swift */,
 				ABB389FA1DB95DDB008BF59E /* StructBuilder.swift */,
 				ABB389FB1DB95DDB008BF59E /* SubviewBuilder.swift */,
-				AB9EF7E01DED4BCD0097C3FC /* ItemsBuilder.swift */,
 				ABB389FC1DB95DDB008BF59E /* UserDefinedAttributesBuilder.swift */,
 			);
 			path = Builder;
@@ -291,15 +293,15 @@
 		ABB38A001DB95DDB008BF59E /* Model */ = {
 			isa = PBXGroup;
 			children = (
-				ABB38A011DB95DDB008BF59E /* XIBDocument.swift */,
-				AB61CB491DD7A41E009DB519 /* ObjectDefinition.swift */,
-				ABB38A041DB95DDB008BF59E /* Reference.swift */,
-				AB477E331DBF8F2E000A0A56 /* Statement.swift */,
-				ABF8D90E1DC11E75008D9178 /* ValueFormat.swift */,
 				ABF8D90C1DC11A7C008D9178 /* AssociationContext.swift */,
 				AB6415D41DD7A9F500FD0C6C /* Configuration.swift */,
 				AB61CB461DD7A2C0009DB519 /* MappingKey.swift */,
+				AB61CB491DD7A41E009DB519 /* ObjectDefinition.swift */,
 				AB9EF7DC1DED37D10097C3FC /* PostProcessor.swift */,
+				ABB38A041DB95DDB008BF59E /* Reference.swift */,
+				AB477E331DBF8F2E000A0A56 /* Statement.swift */,
+				ABF8D90E1DC11E75008D9178 /* ValueFormat.swift */,
+				ABB38A011DB95DDB008BF59E /* XIBDocument.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -400,7 +402,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0800;
-				LastUpgradeCheck = 0800;
+				LastUpgradeCheck = 1250;
 				ORGANIZATIONNAME = "Brian King";
 				TargetAttributes = {
 					AB9EF79C1DE61A910097C3FC = {
@@ -424,7 +426,7 @@
 			};
 			buildConfigurationList = AB47D9A71DB5A3DD00A7B5E8 /* Build configuration list for PBXProject "Eject" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
@@ -596,20 +598,31 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -644,20 +657,31 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -686,7 +710,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				INFOPLIST_FILE = CocoaTouchExample/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.raizlabs.CocoaTouchExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -703,7 +727,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				INFOPLIST_FILE = CocoaTouchExample/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.raizlabs.CocoaTouchExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -721,15 +745,17 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Eject/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.brianking.Eject;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -739,46 +765,23 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Eject/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.brianking.Eject;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
 		ABB38A461DB95EA0008BF59E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "Mac Developer";
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = "";
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
-				FRAMEWORK_VERSION = A;
-				INFOPLIST_FILE = EjectKit/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.brianking.EjectKit;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_VERSION = 3.0;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		ABB38A471DB95EA0008BF59E /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
@@ -787,7 +790,32 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				FRAMEWORK_VERSION = A;
+				INFOPLIST_FILE = EjectKit/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.brianking.EjectKit;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		ABB38A471DB95EA0008BF59E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_IDENTITY = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = EjectKit/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -796,7 +824,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};

--- a/EjectKit/Builder/CocoaTouchBuilder.swift
+++ b/EjectKit/Builder/CocoaTouchBuilder.swift
@@ -394,7 +394,7 @@ extension DocumentBuilder {
         let button = control.inherit(
             className: "UIButton",
             properties: [
-                .build("buttonType", .enumeration, "custom", .inject),
+                .build("type", .enumeration, "custom", .inject),
                 .build("reversesTitleShadowWhenHighlighted", .boolean),
                 .build("showsTouchWhenHighlighted", .boolean),
                 .build("adjustsImageWhenHighlighted", .boolean),

--- a/EjectKit/CodeGenerators/CodeGeneration.swift
+++ b/EjectKit/CodeGenerators/CodeGeneration.swift
@@ -108,7 +108,7 @@ extension Reference {
         let code = try statements
             .filter { $0.phase == phase }
             .map { try $0.generator.generateCode(in: document) }
-            .flatMap { $0 }
+            .compactMap { $0 }
         document.variableNameOverrides[identifier] = original
         return code
     }

--- a/EjectKit/CodeGenerators/Initializer.swift
+++ b/EjectKit/CodeGenerators/Initializer.swift
@@ -26,7 +26,7 @@ struct Initializer: CodeGenerator {
                 return "\(property): \(value)"
             }
             return nil
-        }.flatMap() { $0 }
+        }.compactMap() { $0 }
 
         return "let \(variable) = \(className)(\(arguments.joined(separator: ", ")))"
     }

--- a/EjectKit/CodeGenerators/ValueCodeGenerators.swift
+++ b/EjectKit/CodeGenerators/ValueCodeGenerators.swift
@@ -12,7 +12,7 @@ struct OptionSetValue: CodeGenerator {
     let keys: [String]
 
     init(attributes: [String: String]) {
-        let keys = attributes.map() { $0.value == "YES" ? .some($0.key) : nil }.flatMap() { $0 }
+        let keys = attributes.map() { $0.value == "YES" ? .some($0.key) : nil }.compactMap() { $0 }
         self.keys = keys
     }
 

--- a/EjectKit/Configuration.swift
+++ b/EjectKit/Configuration.swift
@@ -15,7 +15,11 @@ public struct Configuration {
     public var constraint: ConstraintConfiguration = .anchor
     public var postprocessors: [PostProcessor] = [DuplicateVariableProcessor(), TargetActionConfiguration.PostProcessor()]
     var selfIdentifier: String? = nil
-    public init() {	}
+  public init(_ constraint: ConstraintConfiguration? = nil) {
+    if let constraint = constraint {
+      self.constraint = constraint
+    }
+  }
 }
 
 public enum ConstraintConfiguration: String {

--- a/EjectKit/Foundation+Eject.swift
+++ b/EjectKit/Foundation+Eject.swift
@@ -13,7 +13,7 @@ extension String {
     func snakeCased() -> String {
         var newString = ""
         var previousCharacter: Character? = nil
-        for character in characters {
+        for character in self {
             if previousCharacter == nil {
                 newString.append(String(character).lowercased())
             }
@@ -84,7 +84,7 @@ extension RangeReplaceableCollection where Iterator.Element : Equatable {
 
     mutating func remove(contentsOf array: Array<Iterator.Element>) {
         for item in array {
-            if let index = index(of: item) {
+          if let index = firstIndex(of: item) {
                 remove(at: index)
             }
         }

--- a/EjectKit/XIBParser.swift
+++ b/EjectKit/XIBParser.swift
@@ -103,6 +103,14 @@ public class XIBParser: NSObject {
         return documentBuilder
     }
 
+    // Centralized logic to skip specific elements that don't (and shouldn't) have builders
+    func maybeLogMissingBuilder(elementName: String, attributes: [String: String]) {
+        if elementName == "point" && attributes["key"] == "canvasLocation" {
+            return
+        }
+        document.missingBuilder(forElement: elementName)
+    }
+  
     func enterElement(elementName: String, attributes: [String: String]) {
         guard let builder = builderLookup.lookupBuilder(for: elementName) else {
             document.missingBuilder(forElement: elementName)

--- a/Tests/EjectKitTests/EjectKitTests.swift
+++ b/Tests/EjectKitTests/EjectKitTests.swift
@@ -352,7 +352,7 @@ class EjectTests: XCTestCase {
     func testButton() {
         let xml = wrap("<button contentHorizontalAlignment='center' contentVerticalAlignment='center' lineBreakMode='middleTruncation' id='i5M-Pr-FkT'><rect key='frame' x='11' y='11' width='328' height='578'/><fontDescription key='fontDescription' type='boldSystem' pointSize='15'/><state key='normal' title='Title' image='icon'><color key='titleColor' white='1' alpha='1' colorSpace='calibratedWhite'/><color key='titleShadowColor' white='0.0' alpha='0.0' colorSpace='calibratedWhite'/></state><connections><action selector='doThing:' destination='-1' eventType='touchUpInside' id='39P-Rs-7z2'/></connections></button>")
         checkXML(xml, [
-            "let button = UIButton(buttonType: .custom)",
+            "let button = UIButton(type: .custom)",
             "button.titleLabel?.lineBreakMode = .byTruncatingMiddle",
             "button.titleLabel?.font = .boldSystemFont(ofSize: 15)",
             "button.setTitle(\"Title\", for: .normal)",


### PR DESCRIPTION
IB leaves "Stuff" in the xibs that aren't necessary to port, and generate mysterious warnings when Ejecting. Centralized the logic to suppress them both to keep the real logic clean, and because I anticipate finding more elements that need attention.

Requires [40](https://github.com/Rightpoint/Eject/pull/40) to merge first.